### PR TITLE
Update glue to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,8 +1680,8 @@ dependencies = [
 
 [[package]]
 name = "glue"
-version = "0.8.0"
-source = "git+https://github.com/DelftMercurians/glue.git?tag=v0.8.0#7cf5035e6f6f7da06d1b6cfd0937bccbdebf4f4f"
+version = "0.8.1"
+source = "git+https://github.com/DelftMercurians/glue.git?tag=v0.8.1#cbff9ab9caf7961ce28426d9880fd231638307c6"
 dependencies = [
  "bindgen",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,8 +1680,8 @@ dependencies = [
 
 [[package]]
 name = "glue"
-version = "0.7.9"
-source = "git+https://github.com/DelftMercurians/glue.git?tag=v0.7.10#36eff5802c50e70580e635bab97c27b25cd9169a"
+version = "0.8.0"
+source = "git+https://github.com/DelftMercurians/glue.git?tag=v0.8.0#7cf5035e6f6f7da06d1b6cfd0937bccbdebf4f4f"
 dependencies = [
  "bindgen",
  "chrono",

--- a/crates/dies-basestation-client/Cargo.toml
+++ b/crates/dies-basestation-client/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.79"
 dies-core = { version = "0.1.0", path = "../dies-core" }
 log = "0.4.21"
 tokio = { version = "1.35.1", features = ["rt", "sync"] }
-glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.7.10" }
+glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.0" }
 
 [lints]
 workspace = true

--- a/crates/dies-basestation-client/Cargo.toml
+++ b/crates/dies-basestation-client/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.79"
 dies-core = { version = "0.1.0", path = "../dies-core" }
 log = "0.4.21"
 tokio = { version = "1.35.1", features = ["rt", "sync"] }
-glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.0" }
+glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.1" }
 
 [lints]
 workspace = true

--- a/crates/dies-basestation-client/src/basestation_client.rs
+++ b/crates/dies-basestation-client/src/basestation_client.rs
@@ -245,7 +245,7 @@ impl BasestationHandle {
                                                 msg.kicker_status(),
                                             ),
                                             imu_status: SysStatus::from_option(msg.imu_status()),
-                                            fan_status: SysStatus::from_option(msg.fan_status()),
+                                            tof_status: SysStatus::from_option(msg.tof_status()),
                                             kicker_cap_voltage: msg.kicker_cap_voltage(),
                                             kicker_temp: msg.kicker_temperature(),
                                             motor_statuses: msg

--- a/crates/dies-core/Cargo.toml
+++ b/crates/dies-core/Cargo.toml
@@ -14,7 +14,7 @@ nalgebra = { version = "0.32.3", features = ["serde-serialize"] }
 rand = "0.8.5"
 serde = { version = "1.0.192", features = ["derive"] }
 typeshare = "1.0.3"
-glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.7.10" }
+glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.0" }
 serde_json = "1.0.120"
 tokio = { version = "1.38.0", features = ["fs", "io-std", "rt", "sync"] }
 uuid = { version = "1.9.1", features = ["v4"] }

--- a/crates/dies-core/Cargo.toml
+++ b/crates/dies-core/Cargo.toml
@@ -14,7 +14,7 @@ nalgebra = { version = "0.32.3", features = ["serde-serialize"] }
 rand = "0.8.5"
 serde = { version = "1.0.192", features = ["derive"] }
 typeshare = "1.0.3"
-glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.0" }
+glue = { git = "https://github.com/DelftMercurians/glue.git", tag = "v0.8.1" }
 serde_json = "1.0.120"
 tokio = { version = "1.38.0", features = ["fs", "io-std", "rt", "sync"] }
 uuid = { version = "1.9.1", features = ["v4"] }

--- a/crates/dies-core/src/player.rs
+++ b/crates/dies-core/src/player.rs
@@ -140,11 +140,14 @@ impl From<PlayerMoveCmd> for glue::Radio_Command {
                 y: val.sy as f32,
                 z: val.w as f32,
             },
-            dribbler_speed: val.dribble_speed as f32,
-            robot_command: val.robot_cmd.into(),
-            kick_time: 5_000.0 * val.kick_speed as f32,
-            fan_speed: 0.0,
-            _pad: [0, 0, 0],
+            gen_command: glue::Radio_GenericCommand {
+                dribbler_speed_i: val.dribble_speed as i16,
+                kick_time_i: (5_000.0 * val.kick_speed as f32) as u16,
+                time_to_kick: 0,
+                smart_kick_couter: 0,
+                robot_command: val.robot_cmd.into(),
+            },
+            _pad: [0, 0, 0, 0, 0, 0, 0, 0],
         }
     }
 }
@@ -215,14 +218,16 @@ impl From<PlayerGlobalMoveCmd> for glue::Radio_GlobalCommand {
             global_speed_y: val.global_y as f32,
             heading_last_measurement: val.last_heading as f32,
             heading_setpoint: val.heading_setpoint as f32,
-            dribbler_speed_i: val.dribble_speed as i16,
-            kick_time_i: 5_000,
-            robot_command: val.robot_cmd.into(),
-            smart_kick_couter: val.kick_counter,
-            time_to_kick: 0,
+            gen_command: glue::Radio_GenericCommand {
+                dribbler_speed_i: val.dribble_speed as i16,
+                kick_time_i: 5_000,
+                time_to_kick: 0,
+                smart_kick_couter: val.kick_counter,
+                robot_command: val.robot_cmd.into(),
+            },
             max_yaw_rate: (val.max_yaw_rate * 10.0) as u16,
             preferred_rotation_direction: val.preferred_rotation_direction.as_i8(),
-            _pad2: 0,
+            _pad: 0,
         }
     }
 }
@@ -350,7 +355,7 @@ pub struct PlayerFeedbackMsg {
     pub primary_status: Option<SysStatus>,
     pub kicker_status: Option<SysStatus>,
     pub imu_status: Option<SysStatus>,
-    pub fan_status: Option<SysStatus>,
+    pub tof_status: Option<SysStatus>,
     pub kicker_cap_voltage: Option<f32>,
     pub kicker_temp: Option<f32>,
     pub motor_statuses: Option<[SysStatus; 5]>,
@@ -369,7 +374,7 @@ impl PlayerFeedbackMsg {
             primary_status: None,
             kicker_status: None,
             imu_status: None,
-            fan_status: None,
+            tof_status: None,
             kicker_cap_voltage: None,
             kicker_temp: None,
             motor_statuses: None,

--- a/crates/dies-core/src/player.rs
+++ b/crates/dies-core/src/player.rs
@@ -318,6 +318,7 @@ pub enum SysStatus {
     Safe,
     NotInstalled,
     Standby,
+    Cooldown,
 }
 
 impl SysStatus {
@@ -341,6 +342,7 @@ impl From<glue::HG_Status> for SysStatus {
             glue::HG_Status::SAFE => SysStatus::Safe,
             glue::HG_Status::NOT_INSTALLED => SysStatus::NotInstalled,
             glue::HG_Status::STANDBY => SysStatus::Standby,
+            glue::HG_Status::COOLDOWN => SysStatus::Cooldown,
         }
     }
 }


### PR DESCRIPTION
Update glue to be ABI compatible with the newest robot protocols. Note that additional features will be exposed in the glue API later, this is just so the existing stuff can still run with the new protocols.